### PR TITLE
Mejora de la performance en la ejecucion

### DIFF
--- a/ReasignacionDeChatsMalAsignados
+++ b/ReasignacionDeChatsMalAsignados
@@ -2,6 +2,8 @@ let HP = require('./ElementosDeHighland-Pagination')
 let PC = require('./ProcesamientoDeConversacion')
 let Promise = require('bluebird')
 
-HP.obtenerConversacionesTotales()
-.then(conversaciones => PC.identificadoresDeMiembrosDelEquipo()
-	.then(equipo => Promise.map(conversaciones,conversacion => PC.procesarConversacion(conversacion,equipo),{concurrency:10})))
+Promise.all([
+		HP.obtenerConversacionesTotales(),
+		PC.identificadoresDeMiembrosDelEquipo()
+])
+.then(([conversaciones, equipo]) =>  Promise.map(conversaciones,conversacion => PC.procesarConversacion(conversacion,equipo),{concurrency:7}))


### PR DESCRIPTION
Se agrega un PromiseAll para que la request que devuelve los miembros del equipo y la request que devuelve todas las conversaciones de intercom, se realicen simultaneamente y no secuencialmente.